### PR TITLE
min_mass and max_mass of GCMS data can be found even if initial scan is bad

### DIFF
--- a/pyms/GCMS/Class.py
+++ b/pyms/GCMS/Class.py
@@ -160,13 +160,17 @@ class GCMS_data(pymsBaseClass, TimeListMixin, MaxMinMassMixin, GetIndexTimeMixin
 		for scan in self._scan_list:
 
 			tmp_mini = scan.min_mass
-			if tmp_mini is not None and mini is not None:
-				if tmp_mini < mini:
+			if tmp_mini is not None:
+				if mini is None:
+					mini = tmp_mini
+				elif tmp_mini < mini:
 					mini = tmp_mini
 
 			tmp_maxi = scan.max_mass
-			if tmp_maxi is not None and maxi is not None:
-				if tmp_maxi > maxi:
+			if tmp_maxi is not None:
+				if maxi is None:
+					maxi = tmp_maxi
+				elif tmp_maxi > maxi:
 					maxi = tmp_maxi
 
 		self._min_mass = mini


### PR DESCRIPTION
If the initialization of mini and maxi (lines 158,159) fails, and they are 'None', it doesn't matter that future scans do hold valid data, and min_mass, max_mass will be 'None'.

This issue crushed one of my analyses as the max_mass was not defined. It works well now.

What I did is just set the first encountered mass as the mini or maxi, if they were previously None.