### PR TITLE
Close opened files in process

### DIFF
--- a/pyms/GCMS/IO/ANDI.py
+++ b/pyms/GCMS/IO/ANDI.py
@@ -107,7 +107,8 @@ def ANDI_reader(file_name: PathLike) -> GCMS_data:
 	# sanity check
 	if len(time_list) != len(scan_list):
 		raise ValueError("number of time points does not equal the number of scans")
-
+		
+	rootgrp.close()
 	return GCMS_data(time_list, scan_list)
 
 


### PR DESCRIPTION
Opening the file using netCDF4.Dataset results in an open file which results in the following error (in windows) when trying to remove the file. `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process:  <file-name>` A similar error could occur in linux distributions.

This change closes the opened file so that it can be deleted